### PR TITLE
Fix Dockerfile to correct path to requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.8-slim-buster
+
+EXPOSE 8501
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    software-properties-common \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip3 install -r setup/requirements.txt
+
+ENTRYPOINT ["streamlit", "run", "streamlit/main_app.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
The build threw an error due to the incorrect path to the requirements.txt file. We added the `setup/` to correct the path.