### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ WORKDIR /app
 
 COPY . /app
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r setup/requirements.txt
 
 ENTRYPOINT ["streamlit", "run", "streamlit/main_app.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
The build failed due to incorrect path to the requirements.txt file. We added `setup/` to the path to correct the issue.